### PR TITLE
[nit] wording fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Link to PiSugar Case: https://github.com/PiSugar/PiSugar/tree/master/model
 
 Link to PiSugar2 Case: https://github.com/PiSugar/PiSugar/tree/master/model2
 
-Link to PiSugar2 Case: https://github.com/PiSugar/PiSugar/tree/master/model3
+Link to PiSugar3 Case: https://github.com/PiSugar/PiSugar/tree/master/model3
 
 Link to PHAT Caps: https://github.com/PiSugar/pisugar-case-pihat-cap
 


### PR DESCRIPTION
under "PiSugar Case" 
the entry for the pisugar3 is wrongly named pisugar2